### PR TITLE
[CI] Remove dependabot.yml from wrong place

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,7 +1,0 @@
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
I just noticed why we get email 'spam' about failed dependabot runs in this repo and not the others.
The correct place for the YAML is `.github` and we have a second one in the wrong place in `.github/workflows`.
This PR removes the second file.