### PR TITLE
Reorganize inplacelu tests and set failing test to broken on nightly.

### DIFF
--- a/test/test_inplacelu.jl
+++ b/test/test_inplacelu.jl
@@ -170,8 +170,13 @@ function runtests()
     @test m2 == 0
     m3 = @allocated inplacelu_piv_marray(10, Dual64)
     @test m3 == 0
+
     m4 = @allocated inplacelu_piv_stridearray(10, Dual64)
-    @test m4 == 0
+    if VERSION<v"1.11.999"
+        @test m4 == 0
+    else
+        @test_broken m4 == 0
+    end
     return true
 end
 

--- a/test/test_inplacelu.jl
+++ b/test/test_inplacelu.jl
@@ -143,7 +143,7 @@ const Dual64 = ForwardDiff.Dual{Float64, Float64, 1}
 function runtests()
     # Check if Dual64 is fully parametrized
     @test isbitstype(Dual64)
-    
+
     # first precompile to avoid allocations during precompilation
     inplacelu_nopiv_marray(10, Float64)
     inplacelu_nopiv_stridearray(10, Float64)
@@ -172,7 +172,7 @@ function runtests()
     @test m3 == 0
 
     m4 = @allocated inplacelu_piv_stridearray(10, Dual64)
-    if VERSION<v"1.11.999"
+    if VERSION < v"1.11.999"
         @test m4 == 0
     else
         @test_broken m4 == 0

--- a/test/test_inplacelu.jl
+++ b/test/test_inplacelu.jl
@@ -1,4 +1,4 @@
-module test_linsolve
+module test_inplacelu
 using VoronoiFVM
 using Test
 using StrideArraysCore: StrideArray, @gc_preserve, StaticInt


### PR DESCRIPTION
The failing test concerns pivoting inplace lu factorization for StrideArrays implemented via RecursiveFactorization.jl. The test is relevant for problems like Example510 where we
need to solve a linear system in flux functions while avoiding allocations. It is not
relevant for the core package functionality.

Workarounds:
- dont't use the pivoting version but our own non-pivoting implementation of the Doolittle method
- Work with MArrays from StaticArrays (which are anyway more mature than StrideArrays)
 
Set the test to `broken` in order to be discover  other more important problems.
  