### PR TITLE
[DownstreamTester] remove hotfix

### DIFF
--- a/.github/workflows/downstreamtester.yml
+++ b/.github/workflows/downstreamtester.yml
@@ -46,10 +46,6 @@ jobs:
         run: |
           julia -e '
             using Pkg
-            try 
-              Pkg.add(url="https://github.com/jpthiele/PrecompileTools.jl", rev="teh/toplevel")
-            catch
-            end
             Pkg.add(name="DownstreamTester",version="0.1")
             using DownstreamTester
             DownstreamTester.nightly(;nightlylabels=["julia nightly"])'


### PR DESCRIPTION
Since a new version of PrecompileTools was released the hotfix can be removed again.