### PR TITLE
Replace Sparsity detection

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 ExtendableGrids = "cfc395e8-590f-11e8-1f13-43a2532b2fa8"
 ExtendableSparse = "95c220a8-a1cf-11e9-0c77-dbfce5f500b3"
@@ -23,10 +24,10 @@ RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 RecursiveFactorization = "f2c3362d-daeb-58d1-803e-2bc74f2840b4"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-SparseDiffTools = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
+SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
+SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 TextWrap = "b718987f-49a8-5099-9789-dcd902bef87d"
 
 [weakdeps]
@@ -34,35 +35,6 @@ ExtendableFEMBase = "12fb9182-3d4c-4424-8fd1-727a0899810c"
 
 [extensions]
 VoronoiFVMExtendableFEMBaseExt = "ExtendableFEMBase"
-
-[extras]
-AMGCLWrap = "4f76b812-4ba5-496d-b042-d70715554288"
-AlgebraicMultigrid = "2169fc97-5a83-5252-b627-83903c6c433c"
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
-ChunkSplitters = "ae650224-84b6-46f8-82ea-d812ca08434e"
-DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-ExampleJuggler = "3bbe58f8-ed81-4c4e-a134-03e85fcf4a1a"
-ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
-ExtendableFEM = "a722555e-65e0-4074-a036-ca7ce79a4aed"
-ExtendableFEMBase = "12fb9182-3d4c-4424-8fd1-727a0899810c"
-HypertextLiteral = "ac1192a8-f4b3-4bfe-ba22-af5b92cd3ab2"
-ILUZero = "88f59080-6952-5380-9ea5-54057fb9a43f"
-Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
-Metis = "2679e427-3c69-5b7f-982b-ece356f1e94b"
-OrdinaryDiffEqBDF = "6ad6398a-0878-4a85-9266-38940aa047c8"
-OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
-OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
-OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
-OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-PlutoUI = "7f904dfe-b85e-4ff6-b463-dae2292396a8"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
-SimplexGridFactory = "57bfcd06-606e-45d6-baf4-4ba06da0efd5"
-StrideArraysCore = "7792a7ef-975c-4747-a70f-980b88e8d1da"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Triangulate = "f7e6ffb2-c36d-4f8f-a77e-16e897189344"
-UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 AMGCLWrap = "2.1.0"
@@ -75,6 +47,7 @@ Colors = "0.12, 0.13"
 CommonSolve = "0.2"
 DataStructures = "0.18.22"
 DiffResults = "1"
+DifferentiationInterface = "0.6.52"
 DocStringExtensions = "0.8,0.9"
 ExampleJuggler = "2"
 ExplicitImports = "1.11.1"
@@ -107,44 +80,45 @@ Revise = "3.7.3"
 SciMLBase = "2.6"
 SimplexGridFactory = "2.4.0"
 SparseArrays = "1.9"
-SparseDiffTools = "^1.19, 2"
+SparseConnectivityTracer = "0.6.17"
+SparseMatrixColorings = "0.4.18"
 StaticArrays = "0.12,1"
-StrideArraysCore = "0.5.7"
 Statistics = "1.9"
-Symbolics = "4.2,5,6"
+StrideArraysCore = "0.5.7"
 Test = "1"
 TextWrap = "1.0.2"
 Triangulate = "2.4.0"
 UUIDs = "1"
 julia = "1.9"
 
+[extras]
+AMGCLWrap = "4f76b812-4ba5-496d-b042-d70715554288"
+AlgebraicMultigrid = "2169fc97-5a83-5252-b627-83903c6c433c"
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
+ChunkSplitters = "ae650224-84b6-46f8-82ea-d812ca08434e"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+ExampleJuggler = "3bbe58f8-ed81-4c4e-a134-03e85fcf4a1a"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+ExtendableFEM = "a722555e-65e0-4074-a036-ca7ce79a4aed"
+ExtendableFEMBase = "12fb9182-3d4c-4424-8fd1-727a0899810c"
+HypertextLiteral = "ac1192a8-f4b3-4bfe-ba22-af5b92cd3ab2"
+ILUZero = "88f59080-6952-5380-9ea5-54057fb9a43f"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+Metis = "2679e427-3c69-5b7f-982b-ece356f1e94b"
+OrdinaryDiffEqBDF = "6ad6398a-0878-4a85-9266-38940aa047c8"
+OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
+OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
+OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
+OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+PlutoUI = "7f904dfe-b85e-4ff6-b463-dae2292396a8"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
+SimplexGridFactory = "57bfcd06-606e-45d6-baf4-4ba06da0efd5"
+StrideArraysCore = "7792a7ef-975c-4747-a70f-980b88e8d1da"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Triangulate = "f7e6ffb2-c36d-4f8f-a77e-16e897189344"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
 [targets]
-test = [
-    "AMGCLWrap",
-    "AlgebraicMultigrid",
-    "Aqua",
-    "Catalyst",
-    "ChunkSplitters",
-    "DataStructures",
-    "ExampleJuggler",
-    "ExplicitImports",
-    "ExtendableFEM",
-    "ExtendableFEMBase",
-    "HypertextLiteral",
-    "ILUZero",
-    "Markdown",
-    "Metis",
-    "OrdinaryDiffEqBDF",
-    "OrdinaryDiffEqLowOrderRK",
-    "OrdinaryDiffEqRosenbrock",
-    "OrdinaryDiffEqSDIRK",
-    "OrdinaryDiffEqTsit5",
-    "Pkg",
-    "PlutoUI",
-    "Revise",
-    "SimplexGridFactory",
-    "StrideArraysCore",
-    "Test",
-    "Triangulate",
-    "UUIDs",
-]
+test = ["AMGCLWrap", "AlgebraicMultigrid", "Aqua", "Catalyst", "ChunkSplitters", "DataStructures", "ExampleJuggler", "ExplicitImports", "ExtendableFEM", "ExtendableFEMBase", "HypertextLiteral", "ILUZero", "Markdown", "Metis", "OrdinaryDiffEqBDF", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqTsit5", "Pkg", "PlutoUI", "Revise", "SimplexGridFactory", "StrideArraysCore", "Test", "Triangulate", "UUIDs"]

--- a/examples/Example210_NonlinearPoisson2D_Reaction.jl
+++ b/examples/Example210_NonlinearPoisson2D_Reaction.jl
@@ -16,7 +16,7 @@ function main(; n = 10, Plotter = nothing, verbose = false, unknown_storage = :s
 
     grid = simplexgrid(X, Y)
 
-    grid = partition(grid, PlainMetisPartitioning(npart = 10))
+    #    grid = partition(grid, PlainMetisPartitioning(npart = 10))
     @show grid
     data = (eps = 1.0e-2, k = 1.0)
 

--- a/examples/Example406_WeirdReaction.jl
+++ b/examples/Example406_WeirdReaction.jl
@@ -57,7 +57,6 @@ function main(;
         verbose = false,
         tend = 1,
         unknown_storage = :sparse,
-        autodetect_sparsity = true
     )
     h = 1.0 / convert(Float64, n)
     X = collect(0.0:h:1.0)
@@ -120,37 +119,14 @@ function main(;
         return nothing
     end
 
-    # If we know the sparsity pattern, we can here create a
-    # sparse matrix with values set to 1 in the nonzero
-    # slots. This allows to circumvent the
-    # autodetection which may takes some time.
-    function generic_operator_sparsity(sys)
-        idx = unknown_indices(unknowns(sys))
-        sparsity = spzeros(num_dof(sys), num_dof(sys))
-        sparsity[idx[iC, 1], idx[iC, 1]] = 1
-        sparsity[idx[iC, 1], idx[iA, 1]] = 1
-        sparsity[idx[iC, 1], idx[iA, 2]] = 1
-        return sparsity
-    end
 
-    if autodetect_sparsity
-        physics = VoronoiFVM.Physics(;
-            breaction = breaction!,
-            generic = generic_operator!,
-            flux = flux!,
-            storage = storage!,
-            source = source!
-        )
-    else
-        physics = VoronoiFVM.Physics(;
-            breaction = breaction!,
-            generic = generic_operator!,
-            generic_sparsity = generic_operator_sparsity,
-            flux = flux!,
-            storage = storage!,
-            source = source!
-        )
-    end
+    physics = VoronoiFVM.Physics(;
+        breaction = breaction!,
+        generic = generic_operator!,
+        flux = flux!,
+        storage = storage!,
+        source = source!
+    )
 
     sys = VoronoiFVM.System(grid, physics; unknown_storage = unknown_storage)
 
@@ -204,9 +180,7 @@ using Test
 function runtests()
     testval = 0.007027597470502758
     @test main(; unknown_storage = :sparse) ≈ testval &&
-        main(; unknown_storage = :dense) ≈ testval &&
-        main(; unknown_storage = :sparse, autodetect_sparsity = false) ≈ testval &&
-        main(; unknown_storage = :dense, autodetect_sparsity = false) ≈ testval
+        main(; unknown_storage = :dense) ≈ testval
     return nothing
 end
 

--- a/src/VoronoiFVM.jl
+++ b/src/VoronoiFVM.jl
@@ -25,13 +25,15 @@ using ExtendableGrids: ExtendableGrids, BEdgeNodes, BFaceCells, BFaceEdges,
     num_partitions, pcolor_partitions, pcolors, num_pcolors,
     PColorPartitions, PartitionCells, PartitionBFaces, PartitionNodes, PartitionEdges
 
+using DifferentiationInterface: DifferentiationInterface, AutoSparse, AutoForwardDiff, prepare_jacobian
+
 using ExtendableSparse: ExtendableSparse, BlockPreconditioner,
     ExtendableSparseMatrix,
     ExtendableSparseMatrixCSC,
     MTExtendableSparseMatrixCSC,
     AbstractExtendableSparseMatrixCSC,
     PointBlockILUZeroPreconditioner, factorize!, flush!,
-    nnz, rawupdateindex!, sparse, updateindex!, nnznew
+    nnz, rawupdateindex!, updateindex!, nnznew
 
 using ForwardDiff: ForwardDiff, value
 using GridVisualize: GridVisualize, GridVisualizer
@@ -48,11 +50,10 @@ import RecursiveFactorization
 using SciMLBase: SciMLBase
 using SparseArrays: SparseArrays, SparseMatrixCSC, dropzeros!, nonzeros,
     nzrange, spzeros, issparse
-using SparseDiffTools: SparseDiffTools, forwarddiff_color_jacobian!,
-    matrix_colors
+using SparseConnectivityTracer: SparseConnectivityTracer, TracerSparsityDetector
+using SparseMatrixColorings: GreedyColoringAlgorithm, sparsity_pattern
 using StaticArrays: StaticArrays, @MVector, @SArray, @SMatrix
 using Statistics: Statistics, mean
-using Symbolics: Symbolics
 using TextWrap: print_wrapped
 
 """

--- a/src/vfvm_assembly.jl
+++ b/src/vfvm_assembly.jl
@@ -600,11 +600,13 @@ function _eval_and_assemble_generic_operator(system::AbstractSystem, matrix, U, 
     y = similar(vecF)
     generic_operator(y, vecU)
     vecF .+= y
-    forwarddiff_color_jacobian!(
-        system.generic_matrix,
+    DifferentiationInterface.jacobian!(
         generic_operator,
-        vecU;
-        colorvec = system.generic_matrix_colors,
+        y,
+        system.generic_matrix,
+        system.generic_matrix_prep,
+        system.generic_matrix_backend,
+        vecU
     )
     rowval = system.generic_matrix.rowval
     colptr = system.generic_matrix.colptr

--- a/src/vfvm_physics.jl
+++ b/src/vfvm_physics.jl
@@ -467,7 +467,9 @@ $(TYPEDSIGNATURES)
 Call function in evaluator, store result and jacobian in predefined memory.
 """
 function evaluate!(e::ResJacEvaluator, u)
-    e.isnontrivial ? ForwardDiff.jacobian!(e.result, e.fwrap, e.y, u, e.config) : nothing
+    if e.isnontrivial
+        ForwardDiff.jacobian!(e.result, e.fwrap, e.y, u, e.config)
+    end
     return nothing
 end
 


### PR DESCRIPTION
- No changes in core functionality
- Replace Symbolics + SparseDiffTools by DifferentiationInterface + SparseConnectivityTracer + SparseMatrixColoring
- Thus at once get rid of dependencies (SparseDiffTools) which probably will not be updated to ForwardDiff 1.0
- Affected: generic operator + measurement_derivative + Example430
- Breaking: remove possibility to provide own sparsity pattern - Performance of SparseConnectivityTracer is good enough now. Could be reintroduced if needed